### PR TITLE
Make utils.parse_json eval-less

### DIFF
--- a/session.js
+++ b/session.js
@@ -93,7 +93,7 @@
         } return (arr ? "[" : "{") + String(json) + (arr ? "]" : "}");
       }
     },
-    parse_json: (JSON.parse || function (str) {
+    parse_json: (JSON.parse || function ( data ) {
       if( typeof data !== "string" || !data )
         return null;
       return ( new Function( "return " + data ) )();


### PR DESCRIPTION
I stole this bit from jQuery - in my opinion a nicer way to parse JSON
