### PR TITLE
Swapped os order check for Linux and Android

### DIFF
--- a/session.js
+++ b/session.js
@@ -155,8 +155,8 @@ var session_fetch = (function(win, doc, nav){
         { string: nav.platform, subString: "Mac", identity: "Mac" },
         { string: nav.userAgent, subString: "iPhone", identity: "iPhone/iPod" },
         { string: nav.userAgent, subString: "iPad", identity: "iPad" },
-        { string: nav.platform, subString: "Linux", identity: "Linux" },
-        { string: nav.userAgent, subString: "Android", identity: "Android" }
+        { string: nav.userAgent, subString: "Android", identity: "Android" },
+        { string: nav.platform, subString: "Linux", identity: "Linux" }
       ]}
   };
 


### PR DESCRIPTION
For os pattern structure: Linux-based Android browsers will match as Linux before reaching the Android pattern. It seems more useful to check Android first (e.g. for user analytics) then move to a Linux check to catch desktop and miscellaneous Linux-based applications. 
