### PR TITLE
Call ipinfodb only when the location cookie expires

### DIFF
--- a/session.js
+++ b/session.js
@@ -307,7 +307,7 @@ var session_fetch = (function(win, doc, nav){
     ipinfodb_location: function(api_key){
       return function (callback){
         var location_cookie = util.get_obj(options.location_cookie);
-        if (location_cookie && location_cookie.source === 'ipinfodb'){ callback(location_cookie); }
+        if (!location_cookie && location_cookie.source === 'ipinfodb'){ 
         win.ipinfocb = function(data){
           if (data.statusCode === "OK"){
             data.source = "ipinfodb";
@@ -321,6 +321,7 @@ var session_fetch = (function(win, doc, nav){
             else { callback({error: true, source: "ipinfodb", message: data.statusMessage}); }
           }}
         util.embed_script("http://api.ipinfodb.com/v3/ip-city/?key=" + api_key + "&format=json&callback=ipinfocb");
+        } else { callback(location_cookie); }
       }}
   };
 


### PR DESCRIPTION
Previously, session.js would call the ipinfodb service on every user's request and reset the cookie, even if the cookie was already present. Now ipinfodb will only set the user location if the cookie doesn't already exist. 
