### PR TITLE
Fix IE11 detection, fix tests for IE

### DIFF
--- a/session.js
+++ b/session.js
@@ -162,6 +162,7 @@ var session_fetch = (function(win, doc, nav){
         { string: nav.vendor, subString: "Camino", identity: "Camino" },
         { string: nav.userAgent, subString: "Netscape", identity: "Netscape" },
         { string: nav.userAgent, subString: "MSIE", identity: "Explorer", versionSearch: "MSIE" },
+        { string: nav.userAgent, subString: "Trident", identity: "Explorer", versionSearch: "rv" },
         { string: nav.userAgent, subString: "Gecko", identity: "Mozilla", versionSearch: "rv" },
         { string: nav.userAgent, subString: "Mozilla", identity: "Netscape", versionSearch: "Mozilla" }
       ],

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -25,6 +25,7 @@
   <script type="text/javascript" src="../session.js"></script>
 
   <!-- include spec files -->
+  <script type="text/javascript" src="spec/browser-spec.js"></script>
   <script type="text/javascript" src="spec/session-info-spec.js"></script>
   <script type="text/javascript" src="spec/timezone-spec.js"></script>
   <script type="text/javascript" src="spec/session-api-spec.js"></script>

--- a/test/spec/browser-spec.js
+++ b/test/spec/browser-spec.js
@@ -1,25 +1,45 @@
 // @todo - can tests be dynamically created in Jasmine for this to work?
-/*
 
-var mock = create_mock()
+var mock = create_mock();
+var _getTestHandler = function(testData, expectedResult) {
+  return function() {
+    mock.nav.userAgent = testData[3];
+    mock.nav.appVersion = testData[2];
+    mock.nav.platform = testData[1];
+    mock.run_sess();
+
+    var browser_data = mock.win.session.browser;
+    expect(browser_data.browser).toEqual(expectedResult.browser);
+    expect(browser_data.version).toEqual(expectedResult.version);
+    expect(browser_data.os).toEqual(expectedResult.os);
+  };
+};
 
 describe('IE Browser Names', function(){
   var ie_tests = [
-    ['mise 9',        'Win', '9.0', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'],
-    ['mise 8 .net',   'Win', '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E)'],
-    ['mise 9',        'Win', '9.0', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)'],
-    ['mise 8 .net',   'Win', '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)'],
-    ['mise 8 .net 2', 'Win', '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)']
+    ['msie 11',       'Win', '11.0', 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko'],
+    ['msie 10',       'Win', '10.0', 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)'],
+    ['msie 9',        'Win',  '9.0', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'],
+    ['msie 8 .net',   'Win',  '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E)'],
+    ['msie 9',        'Win',  '9.0', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)'],
+    ['msie 8 .net',   'Win',  '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)'],
+    ['msie 8 .net 2', 'Win',  '8.0', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)']
   ];
-  for (var i = 0; i < ie_tests.length; i++){
+  var ie_tests_expected_result = [
+    { browser: 'Explorer', version: 11, os: 'Windows' },
+    { browser: 'Explorer', version: 10, os: 'Windows' },
+    { browser: 'Explorer', version:  9, os: 'Windows' },
+    { browser: 'Explorer', version:  8, os: 'Windows' },
+    { browser: 'Explorer', version:  9, os: 'Windows' },
+    { browser: 'Explorer', version:  8, os: 'Windows' },
+    { browser: 'Explorer', version:  8, os: 'Windows' },
+  ];
+  for (var i = 0; i < ie_tests.length; i++) {
     var ie_test = ie_tests[i];
-      it(ie_test[0], function(){
-        mock.nav.userAgent = ie_test[3];
-        mock.nav.appVersion = ie_test[2];
-        mock.run_sess()
-      })
+    var expected_result = ie_tests_expected_result[i];
+    it(ie_test[0], _getTestHandler(ie_test, expected_result));
   }
-})
+});
 
 describe('Firefox Browser Names', function(){
   var firefox_tests = [
@@ -28,7 +48,7 @@ describe('Firefox Browser Names', function(){
     ['firefox 3.6',   '3.6.24', 'Mozilla/5.0 (X11; U; Linux i686; sk; rv:1.9.2.24) Gecko/20111107 Ubuntu/10.04 (lucid) Firefox/3.6.24'],
     ['firefox beta',  '11.0a2', 'Mozilla/5.0 (X11; Linux x86_64; rv:11.0a2) Gecko/20120107 Firefox/11.0a2']
   ];
-})
+});
 
 describe('Safari Browser Names', function(){
   var safari_tests = [
@@ -38,14 +58,11 @@ describe('Safari Browser Names', function(){
     ['5.1 ipad',       '5.1',   'Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3'],
     ['4.1 iphone',     '5.1',   'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3']
   ];
-  
-})
 
-
+});
 
 describe('Chrome Browser Names', function(){
   var chrome_tests = [
-  
+
   ];
-})
-*/
+});


### PR DESCRIPTION
session.js as it stands right now does not correctly detect IE11. It says it is Mozilla 11.

This happens because useragent has been changed significantly compared to IE10.
IE10: `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)`
IE11: `Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko`

With this pull request I am adding additional logic for browser check + fixing browser detection tests for IE (please tell if it would be useful to fix other tests similar way).
