### PR TITLE
Fix document body check

### DIFF
--- a/session.js
+++ b/session.js
@@ -406,7 +406,7 @@ var session_fetch = (function(win, doc, nav){
       var element  = doc.createElement("script");
       element.type = "text/javascript";
       element.src  = url;
-      doc.getElementsByTagName("body")[0].appendChild(element);
+      (doc.body || doc.getElementsByTagName("body")[0] || doc.head).appendChild(element);
     },
     package_obj: function (obj){
       if(obj) {


### PR DESCRIPTION
It is possible that session.js library is run to early and body is not available yet. In such case we can append script to head.
